### PR TITLE
Remove download of multi packet agent due to a broken link

### DIFF
--- a/build/skc-tools/sgx_agent/build_scripts/sgxagent_build.sh
+++ b/build/skc-tools/sgx_agent/build_scripts/sgxagent_build.sh
@@ -48,11 +48,12 @@ if [ "$OS" == "rhel" ]; then
 	fi
 fi
 
-source download_mpa_uefi_rpm.sh  
-if [ $? -ne 0 ]; then
-        echo "${red} mpa uefi rpm download failed ${reset}"
-        exit
-fi
+# Commenting due to a broken link, this module download is not needed
+# source download_mpa_uefi_rpm.sh  
+# if [ $? -ne 0 ]; then
+#         echo "${red} mpa uefi rpm download failed ${reset}"
+#         exit
+# fi
 
 source build_pckretrieval_tool.sh
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
In `sgxagent_build.sh`, the `download_mpa_uefi_rpm.sh` script is removed from being sourced as it contains a broken link.